### PR TITLE
指定numpy版本，防止 opencv 写入图片异常问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mediapipe
 sounddevice
 tqdm
 scikit-learn
+numpy==1.26.4


### PR DESCRIPTION
指定numpy版本，防止 opencv 写入图片异常问题

https://github.com/kleinlee/DH_live/issues/44
https://github.com/kleinlee/DH_live/issues/42
